### PR TITLE
Add check git_url for embedded, refactored --with-{}_module

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -28,44 +28,41 @@ modules:
       name: ngx_http_dyups_module
       git_url: https://github.com/yzprofile/ngx_http_dyups_module.git
   - module:
-      name: http_gzip_static
+      name: http_gzip_static_module
       type: embedded
   - module:
-      name: http_v2
+      name: http_v2_module
       type: embedded
   - module:
-      name: http_ssl
+      name: http_ssl_module
       type: embedded
   - module:
-      name: http_addition
+      name: http_addition_module
       type: embedded
   - module:
-      name: http_auth_request
+      name: http_auth_request_module
       type: embedded
   - module:
-      name: http_gunzip
+      name: http_gunzip_module
       type: embedded
   - module:
-      name: http_gzip_static
+      name: http_realip_module
       type: embedded
   - module:
-      name: http_realip
+      name: http_secure_link_module
       type: embedded
   - module:
-      name: http_secure_link
+      name: http_slice_module
       type: embedded
   - module:
-      name: http_slice
+      name: http_stub_status_module
       type: embedded
   - module:
-      name: http_stub_status
+      name: http_sub_module
       type: embedded
   - module:
-      name: http_sub
+      name: stream_realip_module
       type: embedded
   - module:
-      name: stream_realip
-      type: embedded
-  - module:
-      name: stream_ssl_preread
+      name: stream_ssl_preread_module
       type: embedded

--- a/src/downloader.py
+++ b/src/downloader.py
@@ -89,7 +89,10 @@ def download_modules(modules):
         common_utils.ensure_directory(os.path.join(config.SRC_PATH, "modules"))
         for module in modules:
             module = module.get('module')
-            if module.get('git_url') is not None:
+            if module.get('type') == "embedded" and module.get('git_url') is not None:
+                nginx_modules.append(download_module_from_git(module))
+                download_module_embedded(module)
+            elif module.get('git_url') is not None:
                 nginx_modules.append(download_module_from_git(module))
             elif module.get('web_url') is not None:
                 nginx_modules.append(download_module_from_web(module))
@@ -186,7 +189,7 @@ def download_module_embedded(module):
     :return:
     """
     if module.get('name') is not None:
-        config.DEFAULT_CONFIGURE_PARAMS.append("--with-{}_module".format(module.get('name')))
+        config.DEFAULT_CONFIGURE_PARAMS.append("--with-{}".format(module.get('name')))
 
 
 def download_package_scripts_deb(src_version):


### PR DESCRIPTION
Было 2 одинаковых блока http_gzip_static в example.config.yaml. Оставил 1.

Добавил проверку git_url для встроенных модулей. Если есть параметр git_url, то модуль скачивается и добавляется "--with"


Убрал добавление "_module" и поправил example.config.yaml, так как не собиралось.
```
--with-http_dav_module_module --add-module=/root/rpmbuild/SOURCES/modules/http_dav_module 
```
либо так
```
--with-http_dav_module --add-module=/root/rpmbuild/SOURCES/modules/http_dav 
```