### PR TITLE
Fix bug in Centos 7 and GitPython 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==4.2b1
 requests==2.20.0
-GitPython==2.1.9
+GitPython==3.1.0
 distro==1.3.0
 packaging==19.0
 beautifulsoup4==4.7.1


### PR DESCRIPTION
Bump version of mofule GitPython to 3.1.0
Because on Centos 7 find bug https://github.com/gitpython-developers/GitPython/issues/241
Issue #25 